### PR TITLE
Fix compile: add missing #include

### DIFF
--- a/gtk3/fcitxtheme.cpp
+++ b/gtk3/fcitxtheme.cpp
@@ -5,6 +5,7 @@
  *
  */
 #include "fcitxtheme.h"
+#include <algorithm>
 #include <cassert>
 #include <fcntl.h>
 #include <fmt/format.h>


### PR DESCRIPTION
GCC 11.1.0 complains about not being able to find the version of
std::min that takes std::initializer_list otherwise.