### PR TITLE
gtk3 wayland: allow the input window to be partly outside of parent window

### DIFF
--- a/gtk3/gtk3inputwindow.cpp
+++ b/gtk3/gtk3inputwindow.cpp
@@ -210,21 +210,15 @@ void Gtk3InputWindow::reposition() {
             posY = y;
         }
 
-        if (posX + width_ > x + w || posY + height_ > y + h) {
+        int oldX, oldY;
+        gdk_window_get_position(gdkWindow, &oldX, &oldY);
+        if (posX + width_ > x + w || posY + height_ > y + h \
+            || oldX != posX || oldY != posY) {
             gtk_widget_hide(window_.get());
             gdk_window_move_to_rect(
                 gdkWindow, &rect_, GDK_GRAVITY_SOUTH_WEST,
                 GDK_GRAVITY_NORTH_WEST,
                 (GdkAnchorHints)(GDK_ANCHOR_SLIDE_X | GDK_ANCHOR_FLIP_Y), 0, 0);
-            gtk_widget_show_all(window_.get());
-            return;
-        }
-
-        int oldX, oldY;
-        gdk_window_get_position(gdkWindow, &oldX, &oldY);
-        if (oldX != posX || oldY != posY) {
-            gtk_widget_hide(window_.get());
-            gdk_window_move(gdkWindow, posX, posY);
             gtk_widget_show_all(window_.get());
         }
     }


### PR DESCRIPTION
After 96511d2f07a489fc8ae6bf2e91067ab94483edd5, the input window will always be inside the parent window, no matter it moves or not. This makes it possible to be partly outside when moving.