### PR TITLE
Depend on gio-unix-2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(PkgConfig)
 find_package(XKBCommon)
 pkg_check_modules(GLib2 REQUIRED IMPORTED_TARGET "glib-2.0>=2.56")
 pkg_check_modules(Gio2 REQUIRED IMPORTED_TARGET "gio-2.0")
+pkg_check_modules(GioUnix2 REQUIRED IMPORTED_TARGET "gio-unix-2.0")
 pkg_check_modules(GObject2 REQUIRED IMPORTED_TARGET "gobject-2.0")
 add_subdirectory(fcitx-gclient)
 

--- a/fcitx-gclient/CMakeLists.txt
+++ b/fcitx-gclient/CMakeLists.txt
@@ -47,9 +47,10 @@ target_include_directories(Fcitx5GClient
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>/Fcitx5/GClient"
     INTERFACE
         "${Gio2_INCLUDE_DIRS}"
+        "${GioUnix2_INCLUDE_DIRS}"
         "${GObject2_INCLUDE_DIRS}"
 )
-target_link_libraries(Fcitx5GClient LINK_PRIVATE PkgConfig::Gio2 PkgConfig::GLib2 PkgConfig::GObject2)
+target_link_libraries(Fcitx5GClient LINK_PRIVATE PkgConfig::Gio2 PkgConfig::GioUnix2 PkgConfig::GLib2 PkgConfig::GObject2)
 
 configure_file(Fcitx5GClient.pc.in ${CMAKE_CURRENT_BINARY_DIR}/Fcitx5GClient.pc @ONLY)
 


### PR DESCRIPTION
fcitxtheme.cpp depends on it, and the build will fail if not pulled in
implicitly via somewhere else:

```
[11/21] Building CXX object gtk4/CMakeFiles/im-fcitx5-gtk4.dir/fcitxtheme.cpp.o
FAILED: gtk4/CMakeFiles/im-fcitx5-gtk4.dir/fcitxtheme.cpp.o
/usr/bin/c++ -Dim_fcitx5_gtk4_EXPORTS -I/buildstream/gnome/sdk/fcitx.bst/_builddir -I/buildstream/gnome/sdk/fcitx.bst/fcitx-gclient/.. -I/buildstream/gnome/sdk/fcitx.bst/_builddir/fcitx-gclient -I/Fcitx5/GClient -isystem /usr/include/glib-2.0 -isystem /usr/lib/x86_64-linux-gnu/glib-2.0/include -isystem /usr/include/sysprof-4 -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/gtk-4.0 -isystem /usr/include/pango-1.0 -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/libpng16 -isystem /usr/include/fribidi -isystem /usr/include/cairo -isystem /usr/include/pixman-1 -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/graphene-1.0 -isystem /usr/lib/x86_64-linux-gnu/graphene-1.0/include -Wall -Wextra -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -O2 -g -DNDEBUG -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -mfpmath=sse -msse -msse2 -pthread -std=c++17 -MD -MT gtk4/CMakeFiles/im-fcitx5-gtk4.dir/fcitxtheme.cpp.o -MF gtk4/CMakeFiles/im-fcitx5-gtk4.dir/fcitxtheme.cpp.o.d -o gtk4/CMakeFiles/im-fcitx5-gtk4.dir/fcitxtheme.cpp.o -c /buildstream/gnome/sdk/fcitx.bst/gtk4/fcitxtheme.cpp
/buildstream/gnome/sdk/fcitx.bst/gtk4/fcitxtheme.cpp:12:10: fatal error: gio/gunixinputstream.h: No such file or directory
   12 | #include <gio/gunixinputstream.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```