### PR TITLE
gtk3/inputwindow.cpp: add <algorithm> for std::max

### DIFF
--- a/gtk3/inputwindow.cpp
+++ b/gtk3/inputwindow.cpp
@@ -7,6 +7,7 @@
 #include "inputwindow.h"
 #include "fcitxtheme.h"
 #include <fcitx-gclient/fcitxgclient.h>
+#include <algorithm>
 #include <functional>
 #include <initializer_list>
 #include <limits>


### PR DESCRIPTION
Without the change build fails on upcoming `gcc-14` as:

    source/gtk4/inputwindow.cpp: In member function 'void fcitx::gtk::InputWindow::paint(cairo_t*, unsigned int, unsigned int)':
    source/gtk4/inputwindow.cpp:563:31: error: no matching function for call to 'max(<brace-enclosed initializer list>)'
      563 |             vheight = std::max({fontHeight, labelH, candidateH});
          |                       ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~