### PR TITLE
Add missing header to fix building with GCC 14

### DIFF
--- a/gtk3/inputwindow.cpp
+++ b/gtk3/inputwindow.cpp
@@ -6,6 +6,7 @@
  */
 #include "inputwindow.h"
 #include "fcitxtheme.h"
+#include <algorithm>
 #include <fcitx-gclient/fcitxgclient.h>
 #include <functional>
 #include <initializer_list>


### PR DESCRIPTION
Address FTBFS with GCC 14
```
/builddir/build/BUILD/fcitx5-gtk-5.1.1/gtk3/inputwindow.cpp:563:31: error: no matching function for call to ‘max(<brace-enclosed initializer list>)’
  563 |             vheight = std::max({fontHeight, labelH, candidateH});
      |                       ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14/bits/stl_uninitialized.h:63,
                 from /usr/include/c++/14/memory:69,
                 from /builddir/build/BUILD/fcitx5-gtk-5.1.1/gtk3/utils.h:13,
                 from /builddir/build/BUILD/fcitx5-gtk-5.1.1/gtk3/inputwindow.h:12,
                 from /builddir/build/BUILD/fcitx5-gtk-5.1.1/gtk3/inputwindow.cpp:7:
/usr/include/c++/14/bits/stl_algobase.h:257:5: note: candidate: ‘template<class _Tp> constexpr const _Tp& std::max(const _Tp&, const _Tp&)’
  257 |     max(const _Tp& __a, const _Tp& __b)
      |     ^~~
/usr/include/c++/14/bits/stl_algobase.h:257:5: note:   candidate expects 2 arguments, 1 provided
/usr/include/c++/14/bits/stl_algobase.h:303:5: note: candidate: ‘template<class _Tp, class _Compare> constexpr const _Tp& std::max(const _Tp&, const _Tp&, _Compare)’
  303 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/usr/include/c++/14/bits/stl_algobase.h:303:5: note:   candidate expects 3 arguments, 1 provided
```