### PR TITLE
Fix incorrect gravity value mapping for Bottom Left

### DIFF
--- a/gtk3/fcitxtheme.cpp
+++ b/gtk3/fcitxtheme.cpp
@@ -56,7 +56,7 @@ Gravity getValue(GKeyFile *configFile, const char *group, const char *key,
     } else if (value == "Center Right") {
         return Gravity::CenterRight;
     } else if (value == "Bottom Left") {
-        return Gravity::BottomRight;
+        return Gravity::BottomLeft;
     } else if (value == "Bottom Center") {
         return Gravity::BottomCenter;
     } else if (value == "Bottom Right") {


### PR DESCRIPTION
Corrects the return value for "Bottom Left" string in gravity enum mapping from BottomRight to BottomLeft.