### PR TITLE
fix(gtk4): correct offset variable in setCursorRect

### DIFF
--- a/gtk4/gtk4inputwindow.cpp
+++ b/gtk4/gtk4inputwindow.cpp
@@ -61,7 +61,7 @@ void Gtk4InputWindow::setCursorRect(GdkRectangle rect) {
         gtk_native_get_surface_transform(native, &offsetX, &offsetY);
     }
     rect.x = px + offsetX;
-    rect.y = py + offsetX;
+    rect.y = py + offsetY;
 
     // Sanitize the rect value to workaround a mutter bug:
     // https://gitlab.gnome.org/GNOME/mutter/-/issues/2525


### PR DESCRIPTION
Fix a bug in Gtk4InputWindow::setCursorRect where the Y coordinate was incorrectly using the X offset (offsetX) instead of the Y offset (offsetY). This would cause incorrect vertical positioning of the input window.