### PR TITLE
update the cursor position when a key is pressed

### DIFF
--- a/gtk3/fcitximcontext.cpp
+++ b/gtk3/fcitximcontext.cpp
@@ -1624,6 +1624,12 @@ static gint _key_snooper_cb(GtkWidget *, GdkEventKey *event, gpointer) {
             break;
         }
 
+        /* set_cursor_location_internal() will get origin from X server,
+         * it blocks UI. So delay it to idle callback. */
+        gdk_threads_add_idle_full(
+            G_PRIORITY_DEFAULT_IDLE, (GSourceFunc)_set_cursor_location_internal,
+            g_object_ref(fcitxcontext), (GDestroyNotify)g_object_unref);
+
         _request_surrounding_text(&fcitxcontext);
         if (G_UNLIKELY(!fcitxcontext))
             return FALSE;


### PR DESCRIPTION
分别在kylin v11、ubuntu 2403、kylin v10 sp1和Ubuntu2004上测试发现：
kylin v11：gtk应用pluma+设置backend=x11+fcitx5；
ubuntu 2403：gtk应用gedit+设置backend=x11+fcitx5；
kylin v10 sp1：gtk应用pluma+默认就是x11环境+使用fcitx4；
Ubuntu2004：gtk应用gedit+默认就是x11环境+使用fcitx4，

使用搜狗输入法，第一次使用时没问题，拖拽记事本移动位置，再使用搜狗输入法是候选词窗口出现在上次的位置上。按下空格按键之后，再次输入时，位置正确。再重复上述拖拽应用，再输入，还是出现在上次输入的位置。


查看搜狗输入法代码发现，搜狗输入法在处理字母按键时，调用了fcitx5的keyEvent.filterAndAccept()函数。在处理空格时，发现没有对keyEvent进行任何处理

跟进查看fcitx5-gtk的代码发现，在不对keyEvent进行任何处理时，会主动更新一下光标位置。在输入法处理了keyEvent时，不会有主动更新光标位置到输入法框架。

对比qt应用发现，qt应用无次问题。
在qt的插件中增加打印信息发现，在每次按键时，不管输入法引擎有无处理该按键。都会主动更新输入法光标位置给到输入法框架。都会调用到该函数：
1. https://github.com/fcitx/fcitx5-qt/blob/master/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp#L401
2. https://github.com/fcitx/fcitx5-qt/blob/master/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp#L577

按照fcitx5-qt中的处理，在fcitx5-gtk中也增加更新光标位置函数调用