### PR TITLE
fix(gtk4): disconnect parent surface handler to avoid use-after-free

### DIFF
--- a/gtk4/gtk4inputwindow.cpp
+++ b/gtk4/gtk4inputwindow.cpp
@@ -17,10 +17,9 @@ Gtk4InputWindow::Gtk4InputWindow(ClassicUIConfig *config, FcitxGClient *client)
 }
 
 Gtk4InputWindow::~Gtk4InputWindow() {
-    if (window_) {
-        g_signal_handlers_disconnect_by_data(window_.get(), this);
-        gdk_surface_destroy(window_.release());
-    }
+    // Disconnect every handler (including the "notify::mapped" one on the
+    // parent surface) and destroy the popup before this object goes away.
+    resetWindow();
     // Clean up weak pointer.
     setParent(nullptr);
 }
@@ -122,6 +121,9 @@ void Gtk4InputWindow::update() {
         that->surfaceNotifyMapped(surface);
     };
     g_signal_connect(surface, "notify::mapped", G_CALLBACK(+mapped), this);
+    notifySurface_ = surface;
+    g_object_add_weak_pointer(G_OBJECT(surface),
+                              reinterpret_cast<gpointer *>(&notifySurface_));
 
     auto surface_render = [](GdkSurface *surface, cairo_region_t *,
                              gpointer user_data) {
@@ -178,10 +180,10 @@ void Gtk4InputWindow::reposition() {
 }
 
 void Gtk4InputWindow::surfaceNotifyMapped(GdkSurface *surface) {
-    if (surface != gdk_popup_get_parent(GDK_POPUP(window_.get()))) {
+    if (!window_) {
         return;
     }
-    if (!window_) {
+    if (surface != gdk_popup_get_parent(GDK_POPUP(window_.get()))) {
         return;
     }
     if (!gdk_surface_get_mapped(surface)) {
@@ -193,15 +195,24 @@ void Gtk4InputWindow::surfaceNotifyMapped(GdkSurface *surface) {
 }
 
 void Gtk4InputWindow::resetWindow() {
+    // Always disconnect the "notify::mapped" handler from the parent surface,
+    // regardless of whether the popup still reports a parent. Otherwise a
+    // stale handler pointing at this object survives the parent window's
+    // destruction and dereferences freed memory (SIGSEGV in
+    // gdk_popup_get_parent).
+    if (notifySurface_) {
+        g_signal_handlers_disconnect_by_data(notifySurface_, this);
+        g_object_remove_weak_pointer(
+            G_OBJECT(notifySurface_),
+            reinterpret_cast<gpointer *>(&notifySurface_));
+        notifySurface_ = nullptr;
+    }
     if (!window_) {
         return;
     }
-    if (auto parent = gdk_popup_get_parent(GDK_POPUP(window_.get()))) {
-        g_signal_handlers_disconnect_by_data(parent, this);
-        g_signal_handlers_disconnect_by_data(window_.get(), this);
-        cairoCcontext_.reset();
-        window_.reset();
-    }
+    g_signal_handlers_disconnect_by_data(window_.get(), this);
+    cairoCcontext_.reset();
+    window_.reset();
 }
 
 void Gtk4InputWindow::syncFontOptions() {

--- a/gtk4/gtk4inputwindow.h
+++ b/gtk4/gtk4inputwindow.h
@@ -36,6 +36,12 @@ private:
     UniqueCPtr<GdkSurface, gdk_surface_destroy> window_;
     UniqueCPtr<GdkCairoContext, g_object_unref> cairoCcontext_;
     GtkWidget *parent_ = nullptr;
+    // Parent surface we connected "notify::mapped" to. Tracked via a weak
+    // pointer so it is cleared automatically if the surface is finalized
+    // before us, and so resetWindow() can always disconnect the handler
+    // (avoids a use-after-free when the parent window is destroyed while a
+    // stale handler still points at this object).
+    GdkSurface *notifySurface_ = nullptr;
     size_t width_ = 1;
     size_t height_ = 1;
     GdkRectangle rect_;


### PR DESCRIPTION
## Problem

The GTK4 input module can crash with a use-after-free when a GTK4 toplevel is destroyed while a preedit/candidate popup is (or was) active.

`Gtk4InputWindow::update()` connects a `notify::mapped` handler to the **parent** surface with `this` as user data:

```cpp
g_signal_connect(surface, "notify::mapped", G_CALLBACK(+mapped), this);
```

…but that handler is never reliably disconnected:

- `~Gtk4InputWindow()` only disconnects handlers from `window_` (the popup), never from the parent surface.
- `resetWindow()` only disconnects the parent handler inside `if (auto parent = gdk_popup_get_parent(...))`, which returns `NULL` exactly once the parent surface begins being destroyed — so the disconnect is skipped.

After the input context is destroyed, the parent surface still holds a `notify::mapped` handler pointing at the freed `Gtk4InputWindow`. When the parent toplevel is later destroyed, the stale handler fires and dereferences freed memory in `surfaceNotifyMapped()` → `gdk_popup_get_parent(GDK_POPUP(window_.get()))`.

This is easy to hit in GTK4 terminal emulators that create/destroy toplevel surfaces frequently (closing a tab/split/window while preedit is active). Observed with [Ghostty](https://ghostty.org) on X11/KDE; reproduced across multiple identical coredumps.

### Backtrace

```
#0  gdk_popup_get_parent              (libgtk-4.so.1)
#1  <surfaceNotifyMapped>             (libim-fcitx5.so)
#2  g_closure_invoke
#5  g_signal_emit_valist
#7  g_object_notify_by_pspec
#8  gdk_surface_destroy
#13 gtk_widget_unrealize
#14 gtk_window_destroy
#21 gtk_window_close
```

(`#0` reads `this->window_` and calls `gdk_popup_get_parent()` on a dangling pointer.)

## Fix

- Track the surface we connect `notify::mapped` to in a new `notifySurface_` member, guarded by a `g_object_add_weak_pointer` so it is cleared automatically if the surface is finalized first.
- `resetWindow()` now **always** disconnects that handler (no longer gated on `gdk_popup_get_parent()` returning the parent).
- Route `~Gtk4InputWindow()` through `resetWindow()` so every handler is dropped before the object goes away.
- Check `window_` first in `surfaceNotifyMapped()` before dereferencing it.

## Environment

- fcitx5-gtk `master` (the affected code in `~Gtk4InputWindow` / `resetWindow` / `surfaceNotifyMapped` is unchanged since 5.1.6)
- GTK 4.22, X11, KDE Plasma
- Verified: with the patched module, repeatedly opening/closing GTK4 surfaces while preedit is active no longer crashes (no new coredumps).